### PR TITLE
Allow `~/.local/share/flatpak:ro` and `/var/lib/flatpak:ro`

### DIFF
--- a/org.freedesktop.appstream-glib.json
+++ b/org.freedesktop.appstream-glib.json
@@ -7,6 +7,7 @@
     "separate-locales": false,
     "finish-args" : [
         "--filesystem=host",
+        "--filesystem=~/.local/share/flatpak:ro",
         "--share=network"
     ],
     "cleanup" : [

--- a/org.freedesktop.appstream-glib.json
+++ b/org.freedesktop.appstream-glib.json
@@ -8,6 +8,7 @@
     "finish-args" : [
         "--filesystem=host",
         "--filesystem=~/.local/share/flatpak:ro",
+        "--filesystem=/var/lib/flatpak:ro",
         "--share=network"
     ],
     "cleanup" : [


### PR DESCRIPTION
Running appstream-glib in `~/.local/share/flatpak` may give a similar error to the following:
```
TheEvilSkeleton@TheMainLaptop ~/.l/s/f/a/o/c/a/f/s/appdata> flatpak run org.freedesktop.appstream-glib validate org.bluesabre.MenuLibre.appdata.xml 
org.bluesabre.MenuLibre.appdata.xml: org.bluesabre.MenuLibre.appdata.xml could not be read: Failed to open file “org.bluesabre.MenuLibre.appdata.xml”: No such file or directory
```

This patch resolves that issue by allowing this directory:
```
TheEvilSkeleton@TheMainLaptop ~/.l/s/f/a/o/c/a/f/s/appdata [1]> flatpak run org.freedesktop.appstream-glib validate org.bluesabre.MenuLibre.appdata.xml
org.bluesabre.MenuLibre.appdata.xml: OK
```